### PR TITLE
Adding stream example using pipes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -91,6 +91,50 @@ Buffer containing a whole number of elements.
 
 Both programs print the same result.
 
+== Streaming example.
+
+You can produce and consume arbitrary data through streams.
+
+*consumer.js*
+
+[source,javascript]
+----
+// You must run the consumer before the producer
+const { Disruptor, DisruptorWriteStream } = require('shared-memory-disruptor');
+
+const d = new Disruptor('/stream', 1000, 1, 1, 0, true, false);
+const rs = new DisruptorReadStream(d)
+
+rs.pipe(process.stdout);
+----
+
+*producer.js*
+
+[source,javascript]
+----
+const { Disruptor, DisruptorWriteStream } = require('shared-memory-disruptor');
+
+process.stdin.pipe(
+    new DisruptorWriteStream(
+        new Disruptor('/stream', 1000, 1, 1, 0, false, false)
+    )
+);
+----
+
+First start the consumer by running on a terminal window:
+
+....
+node consumer.js
+....
+
+This will initialize the memory.
+
+On a new terminal, pipe any data to the producer. For example,
+
+....
+{ while true; do echo $RANDOM; sleep 0.1; done; } | node producer.js
+....
+
 == Install
 
 [source,bash]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,44 @@ test();
 
 Both programs print the same result.
 
+## Streaming example.
+
+You can produce and consume arbitrary data through streams.
+
+**consumer.js**
+```javascript
+// You must run the consumer before the producer
+const { Disruptor, DisruptorWriteStream } = require('shared-memory-disruptor');
+
+const d = new Disruptor('/stream', 1000, 1, 1, 0, true, false);
+const rs = new DisruptorReadStream(d)
+
+rs.pipe(process.stdout);
+```
+
+**producer.js**
+
+```javascript
+const { Disruptor, DisruptorWriteStream } = require('shared-memory-disruptor');
+
+process.stdin.pipe(
+    new DisruptorWriteStream(
+        new Disruptor('/stream', 1000, 1, 1, 0, false, false)
+    )
+);
+```
+
+First start the consumer by running on a terminal window:
+
+    node consumer.js
+
+This will initialize the memory.
+
+On a new terminal, pipe any data to the producer. For example,
+
+
+    { while true; do echo $RANDOM; sleep 0.1; done; } | node producer.js
+
 # Install
 
 ``` bash

--- a/example/stream/README.md
+++ b/example/stream/README.md
@@ -1,0 +1,47 @@
+## Streaming example.
+
+This example shows how to stream arbitrary data to a producer through a pipe.
+
+First start the consumer by running on a terminal window:
+
+    node consumer.js
+
+This will initialize the memory.
+
+On a new terminal, pipe any data to the producer. For example,
+
+
+    { while true; do echo $RANDOM; sleep 0.1; done; } | node producer.js
+
+
+### Multiple consumers
+
+We'll now run two consumers.
+
+On one terminal start the first consumer:
+
+    ID=0 TOTAL=2 node consumer.js
+
+Start another consumer on another terminal:
+
+    ID=1 TOTAL=2 node consumer.js
+
+Start producing a stream of random numbers:
+
+    { while true; do echo $RANDOM; sleep 0.1; done; } | node producer.js
+
+
+Now lets try with 100 consumers. This time we'll run the consumers in the
+same terminal window as background processes:
+
+    TOTAL=100
+    for ID in 0 $(seq $((TOTAL - 1))); do
+       ID=$ID TOTAL=$TOTAL node consumer.js | sed "s/^/Consumer $ID: /" &
+    done
+    { while true; do echo $RANDOM; sleep 0.1; done; } \
+      | TOTAL=$TOTAL node producer.js || true
+
+Press control+c to stop the producer and kill the consumers by calling:
+
+    kill $(jobs -p | grep -E -o "[0-9]+ running.*consumer.js" | cut -d' ' -f1)
+

--- a/example/stream/consumer.js
+++ b/example/stream/consumer.js
@@ -1,0 +1,8 @@
+const {
+    Disruptor,
+    DisruptorReadStream
+} = require('../../');
+
+const d = new Disruptor('/stream', 1000, 1, 1, 0, true, false);
+const rs = new DisruptorReadStream(d);
+rs.pipe(process.stdout);

--- a/example/stream/consumer.js
+++ b/example/stream/consumer.js
@@ -1,8 +1,14 @@
-const {
-    Disruptor,
-    DisruptorReadStream
-} = require('../../');
+// You must run the consumer before the producer
+// See README.md for examples
 
-const d = new Disruptor('/stream', 1000, 1, 1, 0, true, false);
+const { Disruptor, DisruptorReadStream } = require('../../');
+
+// Allow reusing this consumer by providing TOTAL=n and ID from 0 to TOTAL-1
+const id = +(process.env.ID || 0);
+const total = +(process.env.TOTAL || id + 1);
+const init = id === 0;
+
+const d = new Disruptor('/stream', 1000, 1, total, id, init, false);
+
 const rs = new DisruptorReadStream(d);
 rs.pipe(process.stdout);

--- a/example/stream/producer.js
+++ b/example/stream/producer.js
@@ -1,0 +1,15 @@
+// Example using a stream of random numbers:
+//
+//    { while true; do echo -n $RANDOM; done; } | node producer.js
+//
+// You can pipe arbitrary data
+
+const {
+    Disruptor,
+    DisruptorWriteStream
+} = require('../../');
+
+const d = new Disruptor('/stream', 1000, 1, 1, 0, true, false);
+const ws = new DisruptorWriteStream(d);
+
+process.stdin.pipe(ws);

--- a/example/stream/producer.js
+++ b/example/stream/producer.js
@@ -1,15 +1,12 @@
-// Example using a stream of random numbers:
-//
-//    { while true; do echo -n $RANDOM; done; } | node producer.js
-//
-// You can pipe arbitrary data
+// You must run the consumer before the producer
+// See README.md for examples
 
-const {
-    Disruptor,
-    DisruptorWriteStream
-} = require('../../');
+const { Disruptor, DisruptorWriteStream } = require('../../');
 
-const d = new Disruptor('/stream', 1000, 1, 1, 0, true, false);
+// The producer needs to be aware of the number of consumers
+const total = +(process.env.TOTAL || 1)
+
+const d = new Disruptor('/stream', 1000, 1, total, 0, false, false);
 const ws = new DisruptorWriteStream(d);
 
 process.stdin.pipe(ws);


### PR DESCRIPTION
While evaluating this module I found myself looking into the tests to understand how the stream interface works. It seems to be extensively tested, yet while trying a simple example using a stdin pipe like the example on this PR, I couldn't get it to work.

A very simple example with the expected behaviour by using Node.js fs streams:

`consumer.js`

    const fs = require('node:fs');
    const fws = fs.createWriteStream("shared-file");
    process.stdin.pipe(fws);

`producer.js`

    const fs = require('node:fs');
    const frs = fs.createReadStream("shared-file");
    frs.pipe(process.stdout);


On terminal 1 call:

    { while true; do echo -n $RANDOM; done; } | node producer.js

On terminal 2 call:

    node consumer.js


It would be great to have a working stream example that works with node/unix pipes.

A quick debugging session showed that on `DisruptorReadStream` bufs seem to be empty. Any idea about what might be going on?